### PR TITLE
Illustrate Dragging Trajectory

### DIFF
--- a/drag_bench_evaluation/run_drag_diffusion.py
+++ b/drag_bench_evaluation/run_drag_diffusion.py
@@ -155,7 +155,7 @@ def run_drag(source_image,
 
     # feature shape: [1280,16,16], [1280,32,32], [640,64,64], [320,64,64]
     # update according to the given supervision
-    updated_init_code = drag_diffusion_update(model, init_code,
+    updated_init_code, opt_seq = drag_diffusion_update(model, init_code,
         None, t, handle_points, target_points, mask, args)
 
     # hijack the attention module

--- a/drag_ui.py
+++ b/drag_ui.py
@@ -61,6 +61,7 @@ with gr.Blocks() as demo:
             prompt = gr.Textbox(label="Prompt")
             lora_path = gr.Textbox(value="./lora_tmp", label="LoRA path")
             lora_status_bar = gr.Textbox(label="display LoRA training status")
+            results_path = gr.Textbox(value="./results", label="Folder for results")
 
         # algorithm specific parameters
         with gr.Tab("Drag Config"):
@@ -79,6 +80,11 @@ with gr.Blocks() as demo:
                 latent_lr = gr.Number(value=0.01, label="latent lr")
                 start_step = gr.Number(value=0, label="start_step", precision=0, visible=False)
                 start_layer = gr.Number(value=10, label="start_layer", precision=0, visible=False)
+                save_optimization_seq_rgb = gr.Checkbox(
+                    value=False, 
+                    label="Save Opt Seq",
+                    info="Each step of optimization latent is saved in png file. Will take more time."
+                )
 
         with gr.Tab("Base Model Config"):
             with gr.Row():
@@ -136,6 +142,7 @@ with gr.Blocks() as demo:
         with gr.Row():
             pos_prompt_gen = gr.Textbox(label="Positive Prompt")
             neg_prompt_gen = gr.Textbox(label="Negative Prompt")
+            results_path_gen = gr.Textbox(value="./results", label="Folder for results")
 
         with gr.Tab("Generation Config"):
             with gr.Row():
@@ -218,6 +225,11 @@ with gr.Blocks() as demo:
                 latent_lr_gen = gr.Number(value=0.01, label="latent lr")
                 start_step_gen = gr.Number(value=0, label="start_step", precision=0, visible=False)
                 start_layer_gen = gr.Number(value=10, label="start_layer", precision=0, visible=False)
+                save_optimization_seq_rgb_gen = gr.Checkbox(
+                    value=False, 
+                    label="Save Opt Seq",
+                    info="Each step of optimization latent is saved in png file. Will take more time."
+                )
 
     # event definition
     # event for dragging user-input real image
@@ -265,6 +277,8 @@ with gr.Blocks() as demo:
         lora_path,
         start_step,
         start_layer,
+        results_path,
+        save_optimization_seq_rgb,
         ],
         [output_image]
     )
@@ -343,6 +357,8 @@ with gr.Blocks() as demo:
         b2_gen,
         s1_gen,
         s2_gen,
+        results_path_gen,
+        save_optimization_seq_rgb_gen,
         ],
         [output_image_gen]
     )

--- a/utils/drag_utils.py
+++ b/utils/drag_utils.py
@@ -101,6 +101,7 @@ def drag_diffusion_update(model,
     # prepare optimizable init_code and optimizer
     init_code.requires_grad_(True)
     optimizer = torch.optim.Adam([init_code], lr=args.lr)
+    opt_seq = [init_code.detach().clone()]
 
     # prepare for point tracking and background regularization
     handle_points_init = copy.deepcopy(handle_points)
@@ -157,8 +158,9 @@ def drag_diffusion_update(model,
         scaler.step(optimizer)
         scaler.update()
         optimizer.zero_grad()
+        opt_seq.append(init_code.detach().clone())
 
-    return init_code
+    return init_code, opt_seq
 
 def drag_diffusion_update_gen(model,
                               init_code,
@@ -218,6 +220,7 @@ def drag_diffusion_update_gen(model,
 
     # prepare amp scaler for mixed-precision training
     scaler = torch.cuda.amp.GradScaler()
+    opt_seq = [init_code.detach().clone()]
     for step_idx in range(args.n_pix_step):
         with torch.autocast(device_type='cuda', dtype=torch.float16):
             if args.guidance_scale > 1.:
@@ -281,6 +284,7 @@ def drag_diffusion_update_gen(model,
         scaler.step(optimizer)
         scaler.update()
         optimizer.zero_grad()
+        opt_seq.append(init_code.detach().clone())
 
-    return init_code
+    return init_code, opt_seq
 


### PR DESCRIPTION
Visualizing intermediate optimization steps as requested in #18 

Basically, `drag_diffusion_update` now returns optimized latent **and** optimization sequence that is then denoised and decoded in `run_drag`. UI is modified with a checkbox (default False)

Frames are stored in a separate folder and they can be converted to a `gif` or `mp4` with something like:

```
ffmpeg -framerate 10 -i iter_%d.png result.gif
```
Please let me know if you did anything else to produce dragging trajectories for the website.

The following are the results for some random lion stock image (30 optimization steps):

![image](https://github.com/user-attachments/assets/3569c5f8-4a2f-4ee5-9d56-212255855911)

![result](https://github.com/user-attachments/assets/9b0a6f7d-be8d-459f-9777-74d40537fb00)
